### PR TITLE
Use correct command to launch sql-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Apache Flink Web UI is now available at `localhost:8081`
 
 To Access the SQL CLI, execute
 
+It could be done via one-line command
+```
+docker exec -it $(docker ps -qlf name=sql-cli-for-apache-flink-docker_sql-client) /opt/sql-client/sql-client.sh
+```
+
+Or step by step instructions
 ```
 docker ps
 ```
@@ -61,7 +67,7 @@ docker exec -it <CONTAINER_ID> /bin/bash
 Finally execute
 
 ```
-./sql-cli.sh
+./sql-client.sh
 ```
 
 This will popup Flink sql cli


### PR DESCRIPTION


<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
The PR adds 
1. Fix the command to launch sql client: ./sql-cli.sh => sql-client.sh
2. Add one liner to start sql-client:
```
docker exec -it $(docker ps -qlf name=sql-cli-for-apache-flink-docker_sql-client) /opt/sql-client/sql-client.sh

```

# Why this way

1. There is no ./sql-cli.sh => such command fails
2. One line instead of several could minimize amount of manual work and could be easily copy-pasted from README.md

