### PR TITLE
Use 2.12 scala dependencies

### DIFF
--- a/sql-client/Dockerfile
+++ b/sql-client/Dockerfile
@@ -29,8 +29,8 @@ RUN mkdir -p /opt/sql-client/lib
 
 # Download connector libraries
 RUN wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7_2.12/1.13.2/flink-sql-connector-elasticsearch7_2.12-1.13.2.jar \
-    wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka_2.11/1.13.2/flink-sql-connector-kafka_2.11-1.13.2.jar; \
-    wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-jdbc_2.11/1.13.2/flink-connector-jdbc_2.11-1.13.2.jar; \
+    wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka_2.12/1.13.2/flink-sql-connector-kafka_2.12-1.13.2.jar; \
+    wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-jdbc_2.12/1.13.2/flink-connector-jdbc_2.12-1.13.2.jar; \
     wget -P /opt/sql-client/lib/ https://jdbc.postgresql.org/download/postgresql-42.2.19.jre6.jar; \
     wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-avro-confluent-registry/1.13.2/flink-sql-avro-confluent-registry-1.13.2.jar; \
     wget -P /opt/sql-client/lib/ https://github.com/knaufk/flink-faker/releases/download/v0.4.0/flink-faker-0.4.0.jar;


### PR DESCRIPTION


<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

Use scala 2.12 dependencies

# Why this way
There should be scala version 2.12 used as it is mentioned at
https://github.com/aiven/sql-cli-for-apache-flink-docker/blob/a8db9930c0177ba4ddd7e6e575035d5a0025e07f/README.md?plain=1#L5.
So it's better to use 2.12 dependencies
