### PR TITLE
Bump postgresql jdbc to 42.3.3

### DIFF
--- a/sql-client/Dockerfile
+++ b/sql-client/Dockerfile
@@ -32,7 +32,7 @@ RUN mkdir -p /opt/sql-client/lib
 RUN wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7_2.12/1.14.3/flink-sql-connector-elasticsearch7_2.12-1.14.3.jar \
     wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka_2.12/1.14.3/flink-sql-connector-kafka_2.12-1.14.3.jar; \
     wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-jdbc_2.12/1.14.3/flink-connector-jdbc_2.12-1.14.3.jar; \
-    wget -P /opt/sql-client/lib/ https://jdbc.postgresql.org/download/postgresql-42.2.19.jre6.jar; \
+    wget -P /opt/sql-client/lib/ https://jdbc.postgresql.org/download/postgresql-42.3.3.jre6.jar; \
     wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-avro-confluent-registry/1.14.3/flink-sql-avro-confluent-registry-1.14.3.jar; \
     wget -P /opt/sql-client/lib/ https://github.com/knaufk/flink-faker/releases/download/v0.4.1/flink-faker-0.4.1.jar;
 


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
The PR bumps postgresql jdbc driver to 42.3.3

# Why this way
Besides other changes it solves CVE-2022-21724
