### PR TITLE
Upgrade to Java 11

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.2"
 services:
   sql-client:
-    image: ftisiot/flink_sql_cli:1.14.3
+    image: tonyibbs/flink_sql-cli:1.14.4
     depends_on:
       - jobmanager
     environment:
@@ -10,7 +10,7 @@ services:
       - ./settings/:/settings
 
   jobmanager:
-    image: flink:1.14.3-scala_2.12-java8
+    image: flink:1.14.4-scala_2.12-java11
     ports:
       - "8081:8081"
     command: jobmanager
@@ -23,7 +23,7 @@ services:
       - ./data/:/data
 
   taskmanager:
-    image: flink:1.14.3-scala_2.12-java8
+    image: flink:1.14.4-scala_2.12-java11
     depends_on:
       - jobmanager
     command: taskmanager

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.2"
 services:
   sql-client:
-    image: tonyibbs/flink_sql-cli:1.14.4
+    image: ftisiot/flink_sql_cli:1.14.4
     depends_on:
       - jobmanager
     environment:

--- a/sql-client/Dockerfile
+++ b/sql-client/Dockerfile
@@ -21,7 +21,7 @@
 #SQL CLI - inspired by https://github.com/wuchong/flink-sql-demo/tree/v1.11-EN/sql-client
 ###############################################################################
 
-FROM flink:1.14.3-scala_2.12-java8
+FROM flink:1.14.4-scala_2.12-java11
 
 # Create CLI lib folder
 COPY bin/* /opt/sql-client/
@@ -29,11 +29,11 @@ RUN mkdir -p /opt/sql-client/lib
 
 # Download connector libraries
 
-RUN wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7_2.12/1.14.3/flink-sql-connector-elasticsearch7_2.12-1.14.3.jar; \
-    wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka_2.12/1.14.3/flink-sql-connector-kafka_2.12-1.14.3.jar; \
-    wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-jdbc_2.12/1.14.3/flink-connector-jdbc_2.12-1.14.3.jar; \
+RUN wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7_2.12/1.14.4/flink-sql-connector-elasticsearch7_2.12-1.14.4.jar; \
+    wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka_2.12/1.14.4/flink-sql-connector-kafka_2.12-1.14.4.jar; \
+    wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-jdbc_2.12/1.14.4/flink-connector-jdbc_2.12-1.14.4.jar; \
     wget -P /opt/sql-client/lib/ https://jdbc.postgresql.org/download/postgresql-42.3.3.jar; \
-    wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-avro-confluent-registry/1.14.3/flink-sql-avro-confluent-registry-1.14.3.jar; \
+    wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-avro-confluent-registry/1.14.4/flink-sql-avro-confluent-registry-1.14.4.jar; \
     wget -P /opt/sql-client/lib/ https://github.com/knaufk/flink-faker/releases/download/v0.4.1/flink-faker-0.4.1.jar;
 
 # Copy configuration


### PR DESCRIPTION
# About this change - What it does

Upgrade from Java 8 to Java 11

1. Change from Java 8 to Java 11
2. Keep Scala at 2.12
3. Upgrade Flink from 1.14.3 to 1.14.4
4. Use a new flink_sql-cli image built from the new sql-client spec

# Why this way

I wanted to use the SQL CLI for Flink to test https://github.com/aiven/slack-connector-for-apache-flink, but I had problems installing Java 8 on my Mac M1, and also the slack connector seemed to want a later version of Java. Since Java 11 is the default installed on my Mac by homebrew, that is what I chose.

With these changes, I was able to successfully use the SQL queries as documented for the slack connector.


