### PR TITLE
Use flink-faker 0.5.0

### DIFF
--- a/sql-client/Dockerfile
+++ b/sql-client/Dockerfile
@@ -34,7 +34,7 @@ RUN wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/apache
     wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-jdbc/1.15.0/flink-connector-jdbc-1.15.0.jar; \
     wget -P /opt/sql-client/lib/ https://jdbc.postgresql.org/download/postgresql-42.3.6.jar; \
     wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-avro-confluent-registry/1.15.0/flink-sql-avro-confluent-registry-1.15.0.jar; \
-    wget -P /opt/sql-client/lib/ https://github.com/knaufk/flink-faker/releases/download/v0.4.1/flink-faker-0.4.1.jar;
+    wget -P /opt/sql-client/lib/ https://github.com/knaufk/flink-faker/releases/download/v0.5.0/flink-faker-0.5.0.jar;
 
 # Copy configuration
 COPY conf/* /opt/flink/conf/


### PR DESCRIPTION


<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
Update flink-faker
<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->


# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
Based on [compatibility matrix](https://github.com/knaufk/flink-faker#compatibility-matrix) it is better to use flink-faker 0.5.x for flink 1.15.x
